### PR TITLE
Release 11_05_2026

### DIFF
--- a/helm-charts/matatika-catalog/templates/deployment.yaml
+++ b/helm-charts/matatika-catalog/templates/deployment.yaml
@@ -109,18 +109,18 @@ spec:
           httpGet:
             path: /actuator/health/readiness
             port: {{ .Values.appService.internalHttpPort }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 180
           periodSeconds: 30
           timeoutSeconds: 30
-          failureThreshold: 3
+          failureThreshold: 10
           successThreshold: 1
         livenessProbe:
           httpGet:
             path: /actuator/health/liveness
             port: {{ .Values.appService.internalHttpPort }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 180
           periodSeconds: 30
           timeoutSeconds: 30
-          failureThreshold: 3
+          failureThreshold: 10
           successThreshold: 1
 


### PR DESCRIPTION
[chore: update timeout for readiness and liveness probes](https://github.com/Matatika/matatika-build/commit/5d32b5d21401824092510bc07223654a67218262)