### PR TITLE
[MEL-428] fix: adopt pre-existing tasks namespace into Helm management before upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.idea

--- a/scripts/deploy-meltano-catalog.sh
+++ b/scripts/deploy-meltano-catalog.sh
@@ -43,6 +43,7 @@ fi
 
 ELASTICSEARCH_REBUILD=${ELASTICSEARCH_REBUILD:-false}
 
+<<<<<<< Updated upstream:scripts/deploy-meltano-catalog.sh
 # Build-unique value rendered into a pod-template annotation so every deploy
 # rotates the ReplicaSet, even when image.tag is a mutable tag (e.g. latest-dev)
 # whose underlying image has been rebuilt.
@@ -68,6 +69,13 @@ if [[ "$CONTEXT" == gke_* ]]; then
 		--set gcp.cluster.name="$GCP_CLUSTER"
 	)
 fi
+=======
+# Adopt tasks namespace into Helm management if it pre-exists
+TASKS_NS="${STAGE}-tasks"
+kubectl label namespace "${TASKS_NS}" app.kubernetes.io/managed-by=Helm --overwrite || true
+kubectl annotate namespace "${TASKS_NS}" meta.helm.sh/release-name="${RELEASE}" --overwrite || true
+kubectl annotate namespace "${TASKS_NS}" meta.helm.sh/release-namespace="${STAGE}" --overwrite || true
+>>>>>>> Stashed changes:aws-scripts/deploy-meltano-catalog.sh
 
 echo "Upgrading to APP_VERSION: $APP_VERSION, IMAGE_TAG: $IMAGE_TAG"
 helm upgrade \


### PR DESCRIPTION
The `staging-tasks` namespace was created by Terraform and has no Helm ownership metadata. After `feat/meltano-gke` was merged into `dev` (Jun 1), the `meltano-catalog` Helm chart started defining `kind: Namespace` for the tasks namespace — causing `helm upgrade` to fail trying to adopt a namespace it doesn't own.

Added kubectl label/annotate commands to scripts/deploy-meltano-catalog.sh before the `helm upgrade` call to adopt the namespace into Helm management if it pre-exists. Uses `--overwrite` so it's idempotent on subsequent deploys.